### PR TITLE
fix flag processing for clang, reduce unit test time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,11 @@ set(REQUIRED_BOOST_LIBS program_options timer system chrono )
 include(BuildBoost)
 include_directories(${Boost_INCLUDE_DIRS})
 
-if (CMAKE_COMPILER_IS_GNUCC)
+if(${CMAKE_C_COMPILER_ID} MATCHES "GNU|Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall -ansi -pedantic")
 endif ()
 
-if (CMAKE_COMPILER_IS_GNUCXX)
+if(${CMAKE_C_COMPILER_ID} MATCHES "GNU|Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-long-long -Wall -ansi")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wno-variadic-macros")
 endif ()

--- a/test/lib/common/TestUtility.cpp
+++ b/test/lib/common/TestUtility.cpp
@@ -86,7 +86,7 @@ TEST(TestUtility_nf, parse_string_to_cigar_vector) {
     char const* cigar_string = "2S7M1I5M1I6M1I27M1S";
     typedef std::vector<uint32_t> vec_type;
 
-    int const iters = 5000000;
+    int const iters = 500;
     std::cerr << "Parsing cigar string [" << cigar_string << "] "
         << iters << " times...\n";
     std::vector<vec_type> vecs(iters);


### PR DESCRIPTION
one of the unit tests was trying to measure performance by doing
something 5M times. my bad.