### PR TITLE
use boost fusion to eliminate some boilerplate for heterogeneous types

### DIFF
--- a/cmake/BuildBoost.cmake
+++ b/cmake/BuildBoost.cmake
@@ -27,7 +27,7 @@ ExternalDependency_Add(
     BUILD_BYPRODUCTS ${Boost_LIBRARIES}
     ARGS
         URL ${BOOST_URL}
-        URL_MD5 "564efc7a6c7fb746fc06d7da24fa0c74"
+        URL_MD5 "6364a2a634aa62415e52247072ac6888"
         SOURCE_DIR ${BOOST_SRC}
         BINARY_DIR ${BOOST_SRC}
         CONFIGURE_COMMAND "./bootstrap.sh"

--- a/src/lib/common/FusionBase.hpp
+++ b/src/lib/common/FusionBase.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <boost/fusion/include/less.hpp>
+#include <boost/fusion/include/equal_to.hpp>
+#include <boost/fusion/include/hash.hpp>
+
+#include <cstddef>
+
+// This class inherits from StorageType, which is expected to be a boost
+// fusion sequence. Typically, in this project, this will mean a struct
+// defined with BOOST_FUSION_DEFINE_STRUCT_INLINE. This provides us with
+// a fusion sequence over the data members while also allowing us to
+// access them like an ordinary struct.
+//
+// The second template parameter, DerivedType, is a CRTP parameter.
+// Briefly, DerivedType is the type of a child class that is inheriting
+// from this thing, e.g.,
+//
+//      BOOST_FUSION_DEFINE_STRUCT_INLINE(
+//          Whee,
+//          (std::string, name)
+//          (int x)
+//          (int y)
+//      )
+//
+//      struct Whee : FusionBase<WheeStorage, Whee> { ... };
+//
+// This lets us define common functions for DerivedType (Whee!) that make
+// sense across all types of heterogeneous sequences just once, right here
+// in this template (e.g., comparison operators, hash functions, ...).
+template<typename StorageType, typename DerivedType>
+struct FusionBase : StorageType {
+
+#if (__cplusplus >= 201103L)
+    // C++11 constructor, takes any number of arguments and forwards them
+    // to the storage type. boost::fusion sequences provide a constructor
+    // that does element-wise initialization in declaration order.
+    template<typename... Xs>
+    FusionBase(Xs&&... xs)
+        : StorageType(std::forward<Xs>(xs)...)
+    {}
+#endif
+    // NOTE: if C++11 is not enabled, children of FusionBase<S, D> will
+    // have to initialize the data members of S in the BODY of their
+    // constructors (if they wish to do any initialization at all that
+    // is). This is because initializer lists can not be used to
+    // directly initialize members of base classes.
+
+    StorageType const& raw_storage() const {
+        return *static_cast<StorageType const*>(this);
+    }
+
+    friend bool operator<(DerivedType const& x, DerivedType const& y) {
+        return x.raw_storage() < y.raw_storage();
+    }
+
+    friend bool operator==(DerivedType const& x, DerivedType const& y) {
+        return x.raw_storage() == y.raw_storage();
+    }
+
+    friend std::size_t hash_value(DerivedType const& x) {
+        return boost::fusion::hash_value(x);
+    }
+
+    // add more generic operators that work on heterogeneous sequences
+    // here...
+};

--- a/src/lib/common/Parse.hpp
+++ b/src/lib/common/Parse.hpp
@@ -6,9 +6,9 @@
 
 // This is similar to the basic boost::spirit::qi parsing protocol.
 //
-// Given begin and end iterators and a value, attempts to parse it
-// into value and updates the begin iterator to point to the
-// character after the last part of the match.
+// Given begin and end iterators and an object 'value', we attempt to
+// parse the incoming bits into 'value'. The begin iterator is updated
+// to point to the character after the last part of the match.
 //
 // Returns true if a value was extracted, false otherwise. Note that
 // it may be the case that a partial match happened, e.g.,:
@@ -21,7 +21,9 @@
 // bool rv = auto_parse(beg, end, x);
 //
 // In this case, rv == true, and beg points to 'a'. If you want to enforce
-// a full match, you have to check that beg == end after calling.
+// a full match, you have to check that beg == end after calling. If you
+// want to recover from a partial match and restore the previous state,
+// you also need to cache the begin pointer ('beg') and restore it.
 template<typename Iter, typename T>
 bool auto_parse(Iter& beg, Iter const& end, T& value) {
     namespace qi = boost::spirit::qi;

--- a/src/lib/diagnose_dups/Signature.hpp
+++ b/src/lib/diagnose_dups/Signature.hpp
@@ -1,29 +1,33 @@
 #pragma once
 
+#include "common/FusionBase.hpp"
+
 #include <sam.h>
-#include <boost/functional/hash.hpp>
+#include <boost/fusion/include/adapted.hpp>
 
 #include <stdint.h>
 
 //the intent is for this class to store samblaster signatures
 //they will be created directly from a bam1_t record
+BOOST_FUSION_DEFINE_STRUCT_INLINE(
+    SignatureStorage,
+    (int32_t, tid)
+    (int32_t, mtid)
+    (int32_t, pos)
+    (int32_t, mpos)
+    (bool, reverse)
+    (bool, mreverse)
+)
 
-struct Signature {
-    int32_t tid;
-    int32_t mtid;
-    int32_t pos;
-    int32_t mpos;
-    bool reverse;
-    bool mreverse;
-
-    Signature()
-        : tid(-1)
-        , mtid(-1)
-        , pos(-1)
-        , mpos(-1)
-        , reverse(false)
-        , mreverse(false)
-    {}
+struct Signature : FusionBase<SignatureStorage, Signature> {
+    Signature() {
+        this->tid = -1;
+        this->mtid = -1;
+        this->pos = -1;
+        this->mpos = -1;
+        this->reverse = false;
+        this->mreverse = false;
+    }
 
     Signature(bam1_t const* record);
 
@@ -38,57 +42,4 @@ struct Signature {
     bool is_for_rightmost_read() {
         return(tid > mtid || (tid == mtid && mpos < pos));
     }
-
-
-    friend bool operator==(Signature const& lhs, Signature const& rhs) {
-        return lhs.tid == rhs.tid
-            && lhs.mtid == rhs.mtid
-            && lhs.pos == rhs.pos
-            && lhs.mpos == rhs.mpos
-            && lhs.reverse == rhs.reverse
-            && lhs.mreverse == rhs.mreverse;
-    }
-
-    //FIXME The below is ugly. Think about a clear, but concise way to do this.
-    friend bool operator<(Signature const& lhs, Signature const& rhs) {
-        if (lhs.tid < rhs.tid) {
-            return true;
-        }
-        else {
-            if (lhs.tid == rhs.tid) {
-                if (lhs.pos < rhs.pos) {
-                    return true;
-                }
-                else if (lhs.pos == rhs.pos) {
-                    if (lhs.mtid < rhs.mtid) {
-                        return true;
-                    }
-                    else if (lhs.mtid == rhs.mtid) {
-                        if (lhs.mpos < rhs.mpos) {
-                            return true;
-                        }
-                        else if (lhs.mpos == rhs.mpos) {
-                            //this should upcast the bools to int
-                            //false will be 0
-                            //true will be 1
-                            return lhs.reverse < rhs.reverse
-                                || lhs.mreverse < rhs.mreverse;
-                        }
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    friend std::size_t hash_value(Signature const& sig) {
-        std::size_t seed = boost::hash_value(sig.tid);
-        boost::hash_combine(seed, sig.mtid);
-        boost::hash_combine(seed, sig.pos);
-        boost::hash_combine(seed, sig.mpos);
-        boost::hash_combine(seed, sig.reverse);
-        boost::hash_combine(seed, sig.mreverse);
-        return seed;
-    }
-
 };

--- a/src/lib/diagnose_dups/Tile.hpp
+++ b/src/lib/diagnose_dups/Tile.hpp
@@ -1,99 +1,44 @@
 #pragma once
 
-#include <boost/functional/hash.hpp>
+#include "common/FusionBase.hpp"
 
+#include <boost/fusion/adapted.hpp>
+
+#include <algorithm>
 #include <string>
 
-struct Tile {
-    std::string flowcell;
-    int lane;
-    int id;
-    int subtile_x;
-    int subtile_y;
+BOOST_FUSION_DEFINE_STRUCT_INLINE(
+    TileStorage,
+    (std::string, flowcell)
+    (int, lane)
+    (int, id)
+    (int, subtile_x)
+    (int, subtile_y)
+)
 
+struct Tile : FusionBase<TileStorage, Tile> {
     Tile()
-        : flowcell()
-        , lane(0)
-        , id(0)
-        , subtile_x(-1)
-        , subtile_y(-1)
-    {}
+    {
+        lane = 0;
+        id = 0;
+        subtile_x = -1;
+        subtile_y = -1;
+    }
 
-   friend bool operator==(Tile const& lhs, Tile const& rhs) {
-       return same_tile(lhs, rhs)
-           && lhs.subtile_x == rhs.subtile_x
-           && lhs.subtile_y == rhs.subtile_y;
-   }
+    friend bool same_tile(Tile const& lhs, Tile const& rhs) {
+        return lhs.flowcell == rhs.flowcell
+            && lhs.lane == rhs.lane
+            && lhs.id == rhs.id;
+    }
 
-   friend bool same_tile(Tile const& lhs, Tile const& rhs) {
-       return lhs.flowcell == rhs.flowcell
-           && lhs.lane == rhs.lane
-           && lhs.id == rhs.id;
-   }
-
-   friend bool adjacent_tile(Tile const& lhs, Tile const& rhs) {
-       if (lhs.flowcell == rhs.flowcell && lhs.lane == rhs.lane) {
-           //do more work
-           if ( (lhs.id > 2000) == (rhs.id > 2000) ) {
-               if ( abs( int(lhs.id / 100) - int(rhs.id / 100) ) < 2
-                       && abs( int(lhs. id % 100) - int(rhs.id % 100) ) < 2 ) {
-                   return true;
-               }
-               else {
-                   return false;
-               }
-           }
-           else {
-               return false;
-           }
-
-       }
-       else {
-           return false;
-       }
-   }
-
-
-   friend bool operator<(Tile const& lhs, Tile const&rhs) {
-       if (lhs.flowcell < rhs.flowcell) {
-           return true;
-       }
-       else {
-           if (lhs.flowcell == rhs.flowcell) {
-               if (lhs.lane < rhs.lane) {
-                   return true;
-               }
-               else {
-                   if (lhs.lane == rhs.lane) {
-                       if (lhs.id < rhs.id) {
-                           return true;
-                       }
-                       else {
-                           if (lhs.id == rhs.id) {
-                               if (lhs.subtile_x < rhs.subtile_x) {
-                                   return true;
-                               }
-                               else {
-                                   if (lhs.subtile_x == rhs.subtile_x) {
-                                       return lhs.subtile_y < rhs.subtile_y;
-                                   }
-                               }
-                           }
-                       }
-                   }
-               }
-           }
-       }
-       return false;
-   }
-
-   friend std::size_t hash_value(Tile const& tile) {
-       std::size_t seed = boost::hash_value(tile.flowcell);
-       boost::hash_combine(seed, tile.lane);
-       boost::hash_combine(seed, tile.id);
-       boost::hash_combine(seed, tile.subtile_x);
-       boost::hash_combine(seed, tile.subtile_y);
-       return seed;
-   }
+    friend bool adjacent_tile(Tile const& lhs, Tile const& rhs) {
+        // FIXME: magic numbers o: what's 2000, whats 2? (rhetorical)
+        return lhs.flowcell == rhs.flowcell
+            && lhs.lane == rhs.lane
+            && (lhs.id > 2000) == (rhs.id > 2000)
+            && std::abs( int(lhs.id / 100) - int(rhs.id / 100) ) < 2
+            && std::abs( int(lhs. id % 100) - int(rhs.id % 100) ) < 2
+            ;
+    }
 
 };


### PR DESCRIPTION
If you have types where you want lexicographical less than, hash functions, or equality testing over a sequence of heterogeneous types, you can do something like this. I applied this to the Signature class without really reading its less than implementation :) Looks like there are a few other places in the code where this can be used too.